### PR TITLE
Update composer argument syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ $repo_base/skins/Vector
 eof
 
 # Install PHP dependencies.
-time for i in . extensions/*/ skins/*/; do composer -d="$i" install; composer -d="$i" update; done
+time for i in . extensions/*/ skins/*/; do composer --working-dir="$i" install; composer --working-dir="$i" update; done
 
 # Install NPM dependencies.
 cd .. && . ~/.nvm/nvm.sh && nvm use && cd core &&


### PR DESCRIPTION
In case it's of interest, small change to make the command line syntax for running composer a little more reliable on MacOS.